### PR TITLE
sort articles

### DIFF
--- a/src/components/Paginator.jsx
+++ b/src/components/Paginator.jsx
@@ -37,12 +37,19 @@ export default function Paginator({
       // filter out some received items based on queries in the url
       // but do not filter by the "sort_by" query
       let sortByQuery;
+      let sortOrderQuery;
       const filterQueries = [];
       for(const entry of urlQueries.entries()) {
-        if(entry[0] === "sort_by") {
-          sortByQuery = entry[1];
-        } else {
-          filterQueries.push(entry);
+        switch(entry[0]) {
+          case "sort_by":
+            sortByQuery = entry[1];
+            break;
+          case "order":
+            sortOrderQuery = entry[1];
+            break;
+          default:
+            filterQueries.push(entry);
+            break;
         }
       }
       const newItems = data[itemsKey]
@@ -53,6 +60,7 @@ export default function Paginator({
           return true;
         })
         .toSorted(compareByKey(urlQueries.get("sort_by")));
+      if(sortOrderQuery === "desc") newItems.reverse();
       setItems(newItems);
       setIsLoading(false);
     });

--- a/src/components/Paginator.jsx
+++ b/src/components/Paginator.jsx
@@ -55,7 +55,7 @@ export default function Paginator({
       const newItems = data[itemsKey]
         .filter((item) => {
           for(const [key,value] of filterQueries) {
-            if(value !== item[key]) return false;
+            if(value !== "all" && value !== item[key]) return false;
           }
           return true;
         })

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -47,8 +47,7 @@ export default function SearchBar({ setRequestConf, }) {
     <label>
       Topic:
       <select onChange={handleChange} name="topic"
-          defaultValue={searchInputs.topic}
-          value={searchInputs.topic}>
+          defaultValue={searchInputs.topic}>
         {topics.map((topic) => {
           return <option key={topic} value={topic}>
             {topic}
@@ -59,8 +58,7 @@ export default function SearchBar({ setRequestConf, }) {
     <label>
       Sort by:
       <select onChange={handleChange} name="sort_by"
-          defaultValue={searchInputs.sortBy}
-          value={searchInputs.sortBy}>
+          defaultValue={searchInputs.sortBy}>
         {Object.keys(SORTABLE_FIELDS).map((field) => {
             return <option key={field} value={field}>
               {SORTABLE_FIELDS[field]}
@@ -71,8 +69,7 @@ export default function SearchBar({ setRequestConf, }) {
     <label>
       Order:
       <select onChange={handleChange} name="order"
-          defaultValue={searchInputs.order}
-          value={searchInputs.order}>
+          defaultValue={searchInputs.order}>
         <option value="asc">Ascending</option>
         <option value="desc">Descending</option>
       </select>

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -3,6 +3,12 @@ import { useSearchParams, } from "react-router-dom";
 import ErrorMsg from "./ErrorMsg";
 import api from "../api";
 
+// fields the user can sort by. Values are the display names of the fields
+const SORTABLE_FIELDS = {
+  "created_at": "Post Date",
+  "comment_count": "Number of comments",
+  "votes": "votes",
+};
 
 export default function SearchBar({ setRequestConf, }) {
   const [searchInputs, setSearchInputs] = useState({});
@@ -34,16 +40,35 @@ export default function SearchBar({ setRequestConf, }) {
     return <ErrorMsg msg="Topics could not be loaded. Please try again." />;
   }
   return <form className="search-bar">
-    <select onChange={handleChange} name="topic" value={searchInputs.topic}>
-      {topics.map((topic) => {
-        if(topic === urlQueries.get("topic")) {
-          return <option key={topic} value={topic} selected>
-            {topic}
-          </option>;
+    <label>
+      Topic:
+      <select onChange={handleChange} name="topic" value={searchInputs.topic}>
+        {topics.map((topic) => {
+          if(topic === urlQueries.get("topic")) {
+            return <option key={topic} value={topic} selected>
+              {topic}
+            </option>;
         }
         return <option key={topic} value={topic}>{topic}</option>;
-      })}
-    </select>
+        })}
+      </select>
+    </label>
+    <label>
+      Sort by:
+      <select onChange={handleChange} name="sort_by"
+          value={searchInputs.sortBy}>
+        {Object.keys(SORTABLE_FIELDS).map((field) => {
+          if(field === urlQueries.get("sort_by")) {
+            return <option key={field} value={field} selected>
+              {SORTABLE_FIELDS[field]}
+            </option>;
+          }
+          return <option key={field} value={field}>
+            {SORTABLE_FIELDS[field]}
+          </option>;
+        })}
+      </select>
+    </label>
     <button>Search</button>
   </form>;
 }

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -12,7 +12,7 @@ const SORTABLE_FIELDS = {
 
 export default function SearchBar({ setRequestConf, }) {
   const [searchInputs, setSearchInputs] = useState({
-    topic: "coding",
+    topic: "all",
     sortBy: "created_at",
     order: "desc",
   });
@@ -48,6 +48,7 @@ export default function SearchBar({ setRequestConf, }) {
       Topic:
       <select onChange={handleChange} name="topic"
           defaultValue={searchInputs.topic}>
+        <option key="all" value="all">All</option>
         {topics.map((topic) => {
           return <option key={topic} value={topic}>
             {topic}

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -11,7 +11,11 @@ const SORTABLE_FIELDS = {
 };
 
 export default function SearchBar({ setRequestConf, }) {
-  const [searchInputs, setSearchInputs] = useState({});
+  const [searchInputs, setSearchInputs] = useState({
+    topic: "coding",
+    sortBy: "created_at",
+    order: "desc",
+  });
   const [topics, setTopics] = useState([]);
   const [hasErrored, setHasErrored] = useState(false);
   const [urlQueries, setUrlQueries] = useSearchParams();
@@ -42,31 +46,35 @@ export default function SearchBar({ setRequestConf, }) {
   return <form className="search-bar">
     <label>
       Topic:
-      <select onChange={handleChange} name="topic" value={searchInputs.topic}>
+      <select onChange={handleChange} name="topic"
+          defaultValue={searchInputs.topic}
+          value={searchInputs.topic}>
         {topics.map((topic) => {
-          if(topic === urlQueries.get("topic")) {
-            return <option key={topic} value={topic} selected>
-              {topic}
-            </option>;
-        }
-        return <option key={topic} value={topic}>{topic}</option>;
+          return <option key={topic} value={topic}>
+            {topic}
+          </option>;
         })}
       </select>
     </label>
     <label>
       Sort by:
       <select onChange={handleChange} name="sort_by"
+          defaultValue={searchInputs.sortBy}
           value={searchInputs.sortBy}>
         {Object.keys(SORTABLE_FIELDS).map((field) => {
-          if(field === urlQueries.get("sort_by")) {
-            return <option key={field} value={field} selected>
+            return <option key={field} value={field}>
               {SORTABLE_FIELDS[field]}
             </option>;
-          }
-          return <option key={field} value={field}>
-            {SORTABLE_FIELDS[field]}
-          </option>;
         })}
+      </select>
+    </label>
+    <label>
+      Order:
+      <select onChange={handleChange} name="order"
+          defaultValue={searchInputs.order}
+          value={searchInputs.order}>
+        <option value="asc">Ascending</option>
+        <option value="desc">Descending</option>
       </select>
     </label>
     <button>Search</button>

--- a/src/tests.test.js
+++ b/src/tests.test.js
@@ -8,11 +8,63 @@ const imports = Promise.all([
 
 imports.then(([t, utils, assert]) => {
   t.describe("formatDate", () => {
+    const examples = [
+      "2000-02-15T14:00:00.890Z",
+      "2013-12-30T08:02:10.890Z",
+      "2000-02-15T21:09:43.890Z",
+      "1993-10-07T20:47:47.890Z",
+      "1993-10-07T20:47:47.890Z",
+    ];
     t.test("returns a string in the correct format", () => {
-      const date = 1234567890;
-      const result = utils.formatDate(date);
-      assert.equal(typeof(result),"string");
-      assert.match(result, /\d{4}-\d{2}-\d{2}/);
+      let result;
+      examples.forEach((dateStr) => {
+        result = utils.formatDate(Number(new Date(dateStr)));
+        assert.equal(typeof(result),"string");
+        assert.match(result, /\d{4}-\d{2}-\d{2}/);
+      });
+    });
+    t.test("returns the correct date", () => {
+      let result;
+      examples.forEach((dateStr) => {
+        result = utils.formatDate(Number(new Date(dateStr)));
+        assert.equal(result,dateStr.slice(0,10));
+      });
+    });
+    t.test("when passed a second argument equal to true, also adds the time" +
+      "in YYYY-MM-DD HH:MM format",
+      () => {
+        let result;
+        examples.forEach((dateStr) => {
+          result = utils.formatDate(Number(new Date(dateStr)), true);
+          assert.match(result,/\d{4}-\d{2}-\d{2} \d{2}:\d{2}/);
+        });
+      }
+    );
+  });
+  
+  t.describe("utils.compareByKey", () => {
+    const a = {
+      name: "Steve",
+      species: "Salmon",
+      age: 37,
+      fav_ocean: "atlantic",
+    };
+    const b = {
+      name: "Tanisha",
+      age: 27,
+      fav_ocean: "atlantic",
+    };
+    t.test("is pure", () => {
+      const aCopy = structuredClone(a);
+      const bCopy = structuredClone(b);
+      utils.compareByKey("name")(a,b);
+      assert.deepEqual(a, aCopy);
+      assert.deepEqual(b, bCopy);
+    });
+    t.test("compares two objects by the specified key", () => {
+      assert.equal(Math.sign(utils.compareByKey("name")(a,b)), -1);
+      assert.equal(Math.sign(utils.compareByKey("age")(a,b)), 1);
+      assert.equal(Math.sign(utils.compareByKey("fav_ocean")(a,b)), 0);
     });
   });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,40 @@
 /**
- * Converts
+ * Converts a time stamp representing time since Epoch to a string
+ * representation of it in the current locale.
+ *   @param timeSinceEpoch: Number - the time stamp
+ *   @param includeTime: Boolean - whether to include the time as well as
+ *   the date
 */
-export function formatDate(timeSinceEpoch) {
+export function formatDate(timeSinceEpoch,includeTime) {
+  function format2Digits(num) {
+    return num.toString().padStart(2,'0');
+  }
   const postedDate = new Date(timeSinceEpoch);
-  return "".concat(
+  let result = "".concat(
     postedDate.getFullYear(),
     "-",
-    (postedDate.getMonth()+1).toString().padStart(2,'0'),
+    format2Digits(postedDate.getMonth()+1),
     "-",
-    postedDate.getDate());
+    format2Digits(postedDate.getDate()));
+  if(includeTime) {
+    result = result.concat(
+      " ",
+      format2Digits(postedDate.getHours()),
+      ":",
+      format2Digits(postedDate.getMinutes()));
+  }
+  return result;
+}
+
+/**
+ * Makes comparator functions for objects that compares them by a given key.
+ * For use in .sort or .toSorted
+ * @param key: String - the key to sort by
+ */
+export function compareByKey(key) {
+  return function(a,b) {
+    if(a[key] > b[key]) return 1;
+    if(a[key] === b[key]) return 0;
+    return -1;
+  };
 }


### PR DESCRIPTION
This PR adds the ability for the user to sort articles by various fields, in 
ascending or descending order. It also adds an "all" option to the topic 
selector, and finishes testing the formatDate function.

- **>> finish testing formatDate >> add compareByKey utils function > fully tested**
- **>> ad ability to sort articles by certain fields**
- **>> add ability to sort articles in reverse order > only with URL**
- **>> add order selector to SearchBar > refactor SearchBar to remove use of selected attribute**
- **>> bugfix: allow selectors to change value**
- **>> add "all" option to topic selector > tested**
